### PR TITLE
Gracefully handle daemon as sidecar and avoid docker info call

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
           - "29"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set host Docker storage driver
         run: |
           set -euxo pipefail

--- a/dond
+++ b/dond
@@ -350,7 +350,7 @@ for arg in "${original_args[@]}"; do
       for option in "${docker_options_with_value[@]}"; do
         if [[ "${arg}" == "${option}" ]]; then
           skip_next_arg=true
-          continue
+          break
         fi
       done
     else
@@ -381,12 +381,7 @@ for arg in "${command_args[@]}"; do
     arg="${volume_arg}"
   elif [[ "${arg}" == "-v" || "${arg}" == "--volume" || "${arg}" == "--mount" ]]; then
     fix_next_arg=true
-  elif [[ "${arg}" == "-v="* || "${arg}" == "--volume="* ]]; then
-    option_name="${arg%%"="*}"
-    volume_arg="${arg#*"="}"
-    fix_volume_arg
-    arg="${option_name}=${volume_arg}"
-  elif [[ "${arg}" == "--mount="* ]]; then
+  elif [[ "${arg}" == "-v="* || "${arg}" == "--volume="* || "${arg}" == "--mount="* ]]; then
     option_name="${arg%%"="*}"
     volume_arg="${arg#*"="}"
     fix_volume_arg

--- a/dond
+++ b/dond
@@ -96,19 +96,25 @@ function set_container_root_on_host() {
   local result
 
   if [[ -z "${mock_container_root_on_host}" ]]; then
-    local docker_info
-    docker_info="$(
-      "${docker_path}" info --format '{{.Driver}}|{{.DockerRootDir}}'
-    )"
+    local inspect_result
+    if ! inspect_result="$(
+      "${docker_path}" inspect \
+        --format '{{.Driver}}|{{.ResolvConfPath}}|{{with (index . "GraphDriver")}}{{index .Data "MergedDir"}}{{end}}' \
+        "${container_id}" 2>/dev/null
+    )"; then
+      sidecar_mode=true
+      return
+    fi
 
-    local storage_driver="${docker_info%%"|"*}"
-    local docker_data_dir="${docker_info#*"|"}"
+    local storage_driver="${inspect_result%%"|"*}"
+    local rest="${inspect_result#*"|"}"
+    local resolv_conf_path="${rest%%"|"*}"
+    local merged_dir="${rest#*"|"}"
 
     if [[ "${storage_driver}" == "overlay2" ]]; then
-      result="$(
-        "${docker_path}" inspect --format '{{.GraphDriver.Data.MergedDir}}' "${container_id}"
-      )"
+      result="${merged_dir}"
     elif [[ "${storage_driver}" == "overlayfs" ]]; then
+      local docker_data_dir="${resolv_conf_path%"/containers/"*}"
       result="${docker_data_dir}/rootfs/overlayfs/${container_id}"
     else
       error "Unsupported storage driver: ${storage_driver}"
@@ -181,8 +187,14 @@ function fix_volume_arg() {
   if [[ "${container_data_fetched}" == false ]]; then
     set_container_id
     set_container_root_on_host
-    set_parent_container_mounts
+    if [[ "${sidecar_mode}" == false ]]; then
+      set_parent_container_mounts
+    fi
     container_data_fetched=true
+  fi
+
+  if [[ "${sidecar_mode}" == true ]]; then
+    return
   fi
 
   # Check mounts of the parent container to identify whether the source
@@ -372,6 +384,7 @@ unset next_arg_type skip_next_arg docker_command global_options_with_value_fetch
 
 # Finally it's time to transform the volume|mount arguments
 container_data_fetched=false
+sidecar_mode=false
 fix_next_arg=false
 fixed_args=()
 next_extra_args=()

--- a/dond
+++ b/dond
@@ -98,7 +98,7 @@ function set_container_root_on_host() {
   local inspect_result
   if ! inspect_result="$(
     "${docker_path}" inspect \
-      --format '{{printf "%s\n%s\n%s" .Driver .ResolvConfPath .GraphDriver.Data.MergedDir}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
+      --format '{{printf "%s\n%s\n" .Driver .ResolvConfPath}}{{with .GraphDriver}}{{printf "%s" .Data.MergedDir}}{{end}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
       "${container_id}" 2>/dev/null
   )"; then
     likely_sidecar_docker=true

--- a/dond
+++ b/dond
@@ -99,7 +99,7 @@ function set_container_root_on_host() {
     local inspect_result
     if ! inspect_result="$(
       "${docker_path}" inspect \
-        --format '{{.Driver}}|{{.ResolvConfPath}}' \
+        --format '{{.Driver}}|{{.ResolvConfPath}}|{{.GraphDriver.Data.MergedDir}}' \
         "${container_id}" 2>/dev/null
     )"; then
       sidecar_mode=true
@@ -107,14 +107,12 @@ function set_container_root_on_host() {
     fi
 
     local storage_driver="${inspect_result%%"|"*}"
-    local resolv_conf_path="${inspect_result#*"|"}"
+    local rest="${inspect_result#*"|"}"
+    local resolv_conf_path="${rest%%"|"*}"
+    local merged_dir="${rest#*"|"}"
 
     if [[ "${storage_driver}" == "overlay2" ]]; then
-      result="$(
-        "${docker_path}" inspect \
-          --format '{{.GraphDriver.Data.MergedDir}}' \
-          "${container_id}"
-      )"
+      result="${merged_dir}"
     elif [[ "${storage_driver}" == "overlayfs" ]]; then
       local docker_data_dir="${resolv_conf_path%"/containers/"*}"
       result="${docker_data_dir}/rootfs/overlayfs/${container_id}"

--- a/dond
+++ b/dond
@@ -99,7 +99,7 @@ function set_container_root_on_host() {
     local inspect_result
     if ! inspect_result="$(
       "${docker_path}" inspect \
-        --format '{{.Driver}}|{{.ResolvConfPath}}|{{with (index . "GraphDriver")}}{{index .Data "MergedDir"}}{{end}}' \
+        --format '{{.Driver}}|{{.ResolvConfPath}}' \
         "${container_id}" 2>/dev/null
     )"; then
       sidecar_mode=true
@@ -107,12 +107,14 @@ function set_container_root_on_host() {
     fi
 
     local storage_driver="${inspect_result%%"|"*}"
-    local rest="${inspect_result#*"|"}"
-    local resolv_conf_path="${rest%%"|"*}"
-    local merged_dir="${rest#*"|"}"
+    local resolv_conf_path="${inspect_result#*"|"}"
 
     if [[ "${storage_driver}" == "overlay2" ]]; then
-      result="${merged_dir}"
+      result="$(
+        "${docker_path}" inspect \
+          --format '{{.GraphDriver.Data.MergedDir}}' \
+          "${container_id}"
+      )"
     elif [[ "${storage_driver}" == "overlayfs" ]]; then
       local docker_data_dir="${resolv_conf_path%"/containers/"*}"
       result="${docker_data_dir}/rootfs/overlayfs/${container_id}"

--- a/dond
+++ b/dond
@@ -91,7 +91,7 @@ function set_container_id() {
 }
 
 # Gets the root directory of the current/parent container on the host
-# filesystem.
+# filesystem, and reads its mounts.
 function set_container_root_on_host() {
   local result
 
@@ -99,15 +99,19 @@ function set_container_root_on_host() {
     local inspect_result
     if ! inspect_result="$(
       "${docker_path}" inspect \
-        --format '{{.Driver}}|{{.ResolvConfPath}}|{{.GraphDriver.Data.MergedDir}}' \
+        --format '{{.Driver}}|{{.ResolvConfPath}}|{{.GraphDriver.Data.MergedDir}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
         "${container_id}" 2>/dev/null
     )"; then
       likely_sidecar_docker=true
       return
     fi
 
-    local storage_driver="${inspect_result%%"|"*}"
-    local rest="${inspect_result#*"|"}"
+    local inspect_lines=()
+    readarray -t inspect_lines <<<"${inspect_result}"
+    unset inspect_result
+
+    local storage_driver="${inspect_lines[0]%%"|"*}"
+    local rest="${inspect_lines[0]#*"|"}"
     local resolv_conf_path="${rest%%"|"*}"
     local merged_dir="${rest#*"|"}"
 
@@ -119,8 +123,28 @@ function set_container_root_on_host() {
     else
       error "Unsupported storage driver: ${storage_driver}"
     fi
+
+    if [[ "${#inspect_lines[@]}" -gt 1 ]]; then
+      parent_container_mounts=("${inspect_lines[@]:1}")
+    else
+      parent_container_mounts=()
+    fi
+    unset inspect_lines
   else
     result="${mock_container_root_on_host}"
+
+    local inspect_output
+    inspect_output=$(
+      "${docker_path}" inspect \
+        --format '{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "%s:%s\n" .Source .Destination}}{{end}}{{end}}' \
+        "${container_id}"
+    )
+    if [[ -n "${inspect_output}" ]]; then
+      readarray -t parent_container_mounts <<<"${inspect_output}"
+    else
+      parent_container_mounts=()
+    fi
+    unset inspect_output
   fi
 
   # Sanity check
@@ -129,24 +153,6 @@ function set_container_root_on_host() {
   else
     error "Could not get parent container root on host"
   fi
-}
-
-# Reads the mounts of the current/parent container and stores them in the
-# parent_container_mounts array.
-function set_parent_container_mounts() {
-  local inspect_output
-  inspect_output=$(
-    "${docker_path}" inspect \
-      --format '{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "%s:%s\n" .Source .Destination}}{{end}}{{end}}' \
-      "${container_id}"
-  )
-
-  if [[ -n "${inspect_output}" ]]; then
-    readarray -t parent_container_mounts <<<"${inspect_output}"
-  else
-    parent_container_mounts=()
-  fi
-  unset inspect_output
 
   readonly parent_container_mounts
 }
@@ -187,9 +193,6 @@ function fix_volume_arg() {
   if [[ "${container_data_fetched}" == false ]]; then
     set_container_id
     set_container_root_on_host
-    if [[ "${likely_sidecar_docker}" == false ]]; then
-      set_parent_container_mounts
-    fi
     container_data_fetched=true
   fi
 

--- a/dond
+++ b/dond
@@ -102,7 +102,7 @@ function set_container_root_on_host() {
         --format '{{.Driver}}|{{.ResolvConfPath}}|{{.GraphDriver.Data.MergedDir}}' \
         "${container_id}" 2>/dev/null
     )"; then
-      sidecar_mode=true
+      likely_sidecar_docker=true
       return
     fi
 
@@ -187,13 +187,13 @@ function fix_volume_arg() {
   if [[ "${container_data_fetched}" == false ]]; then
     set_container_id
     set_container_root_on_host
-    if [[ "${sidecar_mode}" == false ]]; then
+    if [[ "${likely_sidecar_docker}" == false ]]; then
       set_parent_container_mounts
     fi
     container_data_fetched=true
   fi
 
-  if [[ "${sidecar_mode}" == true ]]; then
+  if [[ "${likely_sidecar_docker}" == true ]]; then
     return
   fi
 
@@ -384,7 +384,7 @@ unset next_arg_type skip_next_arg docker_command global_options_with_value_fetch
 
 # Finally it's time to transform the volume|mount arguments
 container_data_fetched=false
-sidecar_mode=false
+likely_sidecar_docker=false
 fix_next_arg=false
 fixed_args=()
 next_extra_args=()

--- a/dond
+++ b/dond
@@ -98,7 +98,7 @@ function set_container_root_on_host() {
   local inspect_result
   if ! inspect_result="$(
     "${docker_path}" inspect \
-      --format '{{.Driver}}|{{.ResolvConfPath}}|{{.GraphDriver.Data.MergedDir}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
+      --format '{{printf "%s\n%s\n%s" .Driver .ResolvConfPath .GraphDriver.Data.MergedDir}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
       "${container_id}" 2>/dev/null
   )"; then
     likely_sidecar_docker=true
@@ -109,10 +109,9 @@ function set_container_root_on_host() {
   readarray -t inspect_lines <<<"${inspect_result}"
   unset inspect_result
 
-  local storage_driver="${inspect_lines[0]%%"|"*}"
-  local rest="${inspect_lines[0]#*"|"}"
-  local resolv_conf_path="${rest%%"|"*}"
-  local merged_dir="${rest#*"|"}"
+  local storage_driver="${inspect_lines[0]}"
+  local resolv_conf_path="${inspect_lines[1]}"
+  local merged_dir="${inspect_lines[2]}"
 
   if [[ "${storage_driver}" == "overlay2" ]]; then
     result="${merged_dir}"
@@ -123,8 +122,8 @@ function set_container_root_on_host() {
     error "Unsupported storage driver: ${storage_driver}"
   fi
 
-  if [[ "${#inspect_lines[@]}" -gt 1 ]]; then
-    parent_container_mounts=("${inspect_lines[@]:1}")
+  if [[ "${#inspect_lines[@]}" -gt 3 ]]; then
+    parent_container_mounts=("${inspect_lines[@]:3}")
   else
     parent_container_mounts=()
   fi

--- a/dond
+++ b/dond
@@ -95,57 +95,40 @@ function set_container_id() {
 function set_container_root_on_host() {
   local result
 
-  if [[ -z "${mock_container_root_on_host}" ]]; then
-    local inspect_result
-    if ! inspect_result="$(
-      "${docker_path}" inspect \
-        --format '{{.Driver}}|{{.ResolvConfPath}}|{{.GraphDriver.Data.MergedDir}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
-        "${container_id}" 2>/dev/null
-    )"; then
-      likely_sidecar_docker=true
-      return
-    fi
-
-    local inspect_lines=()
-    readarray -t inspect_lines <<<"${inspect_result}"
-    unset inspect_result
-
-    local storage_driver="${inspect_lines[0]%%"|"*}"
-    local rest="${inspect_lines[0]#*"|"}"
-    local resolv_conf_path="${rest%%"|"*}"
-    local merged_dir="${rest#*"|"}"
-
-    if [[ "${storage_driver}" == "overlay2" ]]; then
-      result="${merged_dir}"
-    elif [[ "${storage_driver}" == "overlayfs" ]]; then
-      local docker_data_dir="${resolv_conf_path%"/containers/"*}"
-      result="${docker_data_dir}/rootfs/overlayfs/${container_id}"
-    else
-      error "Unsupported storage driver: ${storage_driver}"
-    fi
-
-    if [[ "${#inspect_lines[@]}" -gt 1 ]]; then
-      parent_container_mounts=("${inspect_lines[@]:1}")
-    else
-      parent_container_mounts=()
-    fi
-    unset inspect_lines
-  else
-    result="${mock_container_root_on_host}"
-
-    local inspect_output
-    inspect_output=$(
-      "${docker_path}" inspect \
-        --format '{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "%s:%s\n" .Source .Destination}}{{end}}{{end}}' \
-        "${container_id}"
-    )
-    if [[ -n "${inspect_output}" ]]; then
-      readarray -t parent_container_mounts <<<"${inspect_output}"
-    else
-      parent_container_mounts=()
-    fi
-    unset inspect_output
+  local inspect_result
+  if ! inspect_result="$(
+    "${docker_path}" inspect \
+      --format '{{.Driver}}|{{.ResolvConfPath}}|{{.GraphDriver.Data.MergedDir}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
+      "${container_id}" 2>/dev/null
+  )"; then
+    likely_sidecar_docker=true
+    return
   fi
+
+  local inspect_lines=()
+  readarray -t inspect_lines <<<"${inspect_result}"
+  unset inspect_result
+
+  local storage_driver="${inspect_lines[0]%%"|"*}"
+  local rest="${inspect_lines[0]#*"|"}"
+  local resolv_conf_path="${rest%%"|"*}"
+  local merged_dir="${rest#*"|"}"
+
+  if [[ "${storage_driver}" == "overlay2" ]]; then
+    result="${merged_dir}"
+  elif [[ "${storage_driver}" == "overlayfs" ]]; then
+    local docker_data_dir="${resolv_conf_path%"/containers/"*}"
+    result="${docker_data_dir}/rootfs/overlayfs/${container_id}"
+  else
+    error "Unsupported storage driver: ${storage_driver}"
+  fi
+
+  if [[ "${#inspect_lines[@]}" -gt 1 ]]; then
+    parent_container_mounts=("${inspect_lines[@]:1}")
+  else
+    parent_container_mounts=()
+  fi
+  unset inspect_lines
 
   # Sanity check
   if [[ "${result}" =~ ^(/[^/]+)+$ ]]; then
@@ -254,7 +237,6 @@ script_path="$(realpath "$0")"
 readonly script_path
 
 # Parse supported environment variables
-readonly mock_container_root_on_host="${DOND_SHIM_MOCK_CONTAINER_ROOT_ON_HOST:-}"
 readonly print_command="${DOND_SHIM_PRINT_COMMAND:-false}"
 
 if [[ -n "${DOND_SHIM_DOCKER_PATH:-}" ]]; then

--- a/dond
+++ b/dond
@@ -98,7 +98,7 @@ function set_container_root_on_host() {
   local inspect_result
   if ! inspect_result="$(
     "${docker_path}" inspect \
-      --format '{{printf "%s\n%s\n" .Driver .ResolvConfPath}}{{with .GraphDriver}}{{printf "%s" .Data.MergedDir}}{{end}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
+      --format '{{printf "%s\n%s\n%s" .Driver .ResolvConfPath .GraphDriver.Data.MergedDir}}{{range .Mounts}}{{if or (eq .Type "bind") (eq .Type "volume")}}{{printf "\n%s:%s" .Source .Destination}}{{end}}{{end}}' \
       "${container_id}" 2>/dev/null
   )"; then
     likely_sidecar_docker=true

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -61,19 +61,19 @@ for docker_version in "${docker_versions[@]}"; do
     grep -q "^docker.orig --host test run --volume ${fixtures_dir}:/wd:ro --mount=type=bind,source=${fixtures_dir},readonly,destination=/wd2 busybox --volume /wd:/wd$"
 
   echo "Same as above (without --mount), but retaining read only mode on auto added volume"
-  "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true --env DOND_SHIM_MOCK_CONTAINER_ROOT_ON_HOST=/container-root --volume "${fixtures_dir}:/wd" --volume "${fixtures_dir}/testfile:/test/testfile" "${image_id}" \
+  "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true --volume "${fixtures_dir}:/wd" --volume "${fixtures_dir}:/test" --volume "${fixtures_dir}/testfile:/test/testfile" "${image_id}" \
     docker --host test run --volume /wd:/wd:ro --volume /test:/test:ro busybox --volume /wd:/wd |
-    grep -q "^docker.orig --host test run --volume ${fixtures_dir}:/wd:ro --volume /container-root/test:/test:ro --volume ${fixtures_dir}/testfile:/test/testfile:ro busybox --volume /wd:/wd$"
+    grep -q "^docker.orig --host test run --volume ${fixtures_dir}:/wd:ro --volume ${fixtures_dir}:/test:ro --volume ${fixtures_dir}/testfile:/test/testfile:ro busybox --volume /wd:/wd$"
 
   echo "Same as above but should not auto add mounts which are not bind mounts"
-  "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true --env DOND_SHIM_MOCK_CONTAINER_ROOT_ON_HOST=/container-root --volume "${fixtures_dir}:/wd" --volume "${fixtures_dir}/testfile:/test/testfile" --mount type=tmpfs,target=/test/tmpfsdir "${image_id}" \
+  "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true --volume "${fixtures_dir}:/wd" --volume "${fixtures_dir}:/test" --volume "${fixtures_dir}/testfile:/test/testfile" --mount type=tmpfs,target=/test/tmpfsdir "${image_id}" \
     docker --host test run --volume /wd:/wd:ro --volume /test:/test:ro busybox --volume /wd:/wd |
-    grep -q "^docker.orig --host test run --volume ${fixtures_dir}:/wd:ro --volume /container-root/test:/test:ro --volume ${fixtures_dir}/testfile:/test/testfile:ro busybox --volume /wd:/wd$"
+    grep -q "^docker.orig --host test run --volume ${fixtures_dir}:/wd:ro --volume ${fixtures_dir}:/test:ro --volume ${fixtures_dir}/testfile:/test/testfile:ro busybox --volume /wd:/wd$"
 
   echo "Same as above (with --mount src and target, dst), but retaining read only mode on auto added volume"
-  "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true --env DOND_SHIM_MOCK_CONTAINER_ROOT_ON_HOST=/container-root --volume "${fixtures_dir}:/wd" --volume "${fixtures_dir}/testfile:/test/testfile" "${image_id}" \
+  "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true --volume "${fixtures_dir}:/wd" --volume "${fixtures_dir}:/test" --volume "${fixtures_dir}/testfile:/test/testfile" "${image_id}" \
     docker --host test run --mount type=bind,src=/wd,target=/wd,readonly --mount type=bind,source=/test,dst=/test,readonly busybox --mount type=bind,source=/wd,destination=/wd,readonly |
-    grep -q "^docker.orig --host test run --mount type=bind,src=${fixtures_dir},target=/wd,readonly --mount type=bind,source=/container-root/test,dst=/test,readonly --mount type=bind,source=${fixtures_dir}/testfile,dst=/test/testfile,readonly busybox --mount type=bind,source=/wd,destination=/wd,readonly$"
+    grep -q "^docker.orig --host test run --mount type=bind,src=${fixtures_dir},target=/wd,readonly --mount type=bind,source=${fixtures_dir},dst=/test,readonly --mount type=bind,source=${fixtures_dir}/testfile,dst=/test/testfile,readonly busybox --mount type=bind,source=/wd,destination=/wd,readonly$"
 
   echo "Same but for container run"
   "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true --volume "${fixtures_dir}:/wd" "${image_id}" \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -36,6 +36,7 @@ unset script_path script_dir
 # this avoids messing with the test output during the tests itself
 echo "Pulling docker images used in tests"
 docker pull -q busybox
+docker pull -q docker:dind
 
 for docker_version in "${docker_versions[@]}"; do
   echo "Testing with docker version: ${docker_version}"
@@ -91,6 +92,18 @@ for docker_version in "${docker_versions[@]}"; do
   "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true --volume "${fixtures_dir}:/wd" "${image_id}" \
     docker --host test whatever --volume /wd:/wd busybox --volume /wd:/wd |
     grep -q "^docker.orig --host test whatever --volume /wd:/wd busybox --volume /wd:/wd$"
+
+  echo "In sidecar mode (e.g. GitLab CI Docker-in-Docker service), volume args pass through unchanged"
+  sidecar_dind_id="$(docker run --detach --privileged --env DOCKER_TLS_CERTDIR="" docker:dind)"
+  until docker exec "${sidecar_dind_id}" docker info >/dev/null 2>&1; do sleep 1; done
+  sidecar_dind_ip="$(docker inspect --format '{{.NetworkSettings.IPAddress}}' "${sidecar_dind_id}")"
+  "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true \
+    --env DOCKER_HOST="tcp://${sidecar_dind_ip}:2375" \
+    --volume "${fixtures_dir}:/wd" "${image_id}" \
+    docker run --volume /wd:/wd busybox |
+    grep -q "^docker.orig run --volume /wd:/wd busybox$"
+  docker rm --force "${sidecar_dind_id}" >/dev/null
+  unset sidecar_dind_id sidecar_dind_ip
 
   echo "Check if docker on docker is working"
   "${docker_args[@]}" "${image_id}" \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -96,14 +96,13 @@ for docker_version in "${docker_versions[@]}"; do
   echo "In sidecar mode (e.g. GitLab CI Docker-in-Docker service), volume args pass through unchanged"
   sidecar_dind_id="$(docker run --detach --privileged --env DOCKER_TLS_CERTDIR="" docker:dind)"
   until docker exec "${sidecar_dind_id}" docker info >/dev/null 2>&1; do sleep 1; done
-  sidecar_dind_ip="$(docker inspect --format '{{.NetworkSettings.IPAddress}}' "${sidecar_dind_id}")"
   "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true \
-    --env DOCKER_HOST="tcp://${sidecar_dind_ip}:2375" \
+    --link "${sidecar_dind_id}:dind" --env DOCKER_HOST="tcp://dind:2375" \
     --volume "${fixtures_dir}:/wd" "${image_id}" \
     docker run --volume /wd:/wd busybox |
     grep -q "^docker.orig run --volume /wd:/wd busybox$"
   docker rm --force "${sidecar_dind_id}" >/dev/null
-  unset sidecar_dind_id sidecar_dind_ip
+  unset sidecar_dind_id
 
   echo "Check if docker on docker is working"
   "${docker_args[@]}" "${image_id}" \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -38,7 +38,6 @@ echo "Pulling docker images used in tests"
 docker pull -q busybox
 for docker_version in "${docker_versions[@]}"; do
   docker pull -q "docker:${docker_version}"
-  docker pull -q "docker:${docker_version}-dind"
 done
 
 for docker_version in "${docker_versions[@]}"; do
@@ -97,15 +96,11 @@ for docker_version in "${docker_versions[@]}"; do
     grep -q "^docker.orig --host test whatever --volume /wd:/wd busybox --volume /wd:/wd$"
 
   echo "Passes through when the Docker is in a sidecar container"
-  sidecar_dind_id="$(docker run --detach --privileged --env DOCKER_TLS_CERTDIR="" "docker:${docker_version}-dind")"
-  until docker exec "${sidecar_dind_id}" docker info >/dev/null 2>&1; do sleep 1; done
   "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true \
-    --link "${sidecar_dind_id}:dind" --env DOCKER_HOST="tcp://dind:2375" \
+    --env DOCKER_HOST="unix:///nonexistent.sock" \
     --volume "${fixtures_dir}:/wd" "${image_id}" \
     docker run --volume /wd:/wd busybox |
     grep -q "^docker.orig run --volume /wd:/wd busybox$"
-  docker rm --force "${sidecar_dind_id}" >/dev/null
-  unset sidecar_dind_id
 
   echo "Check if docker on docker is working"
   "${docker_args[@]}" "${image_id}" \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -37,6 +37,7 @@ unset script_path script_dir
 echo "Pulling docker images used in tests"
 docker pull -q busybox
 for docker_version in "${docker_versions[@]}"; do
+  docker pull -q "docker:${docker_version}"
   docker pull -q "docker:${docker_version}-dind"
 done
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -36,7 +36,7 @@ unset script_path script_dir
 # this avoids messing with the test output during the tests itself
 echo "Pulling docker images used in tests"
 docker pull -q busybox
-docker pull -q docker:dind
+docker pull -q "docker:${docker_version}-dind"
 
 for docker_version in "${docker_versions[@]}"; do
   echo "Testing with docker version: ${docker_version}"
@@ -93,8 +93,8 @@ for docker_version in "${docker_versions[@]}"; do
     docker --host test whatever --volume /wd:/wd busybox --volume /wd:/wd |
     grep -q "^docker.orig --host test whatever --volume /wd:/wd busybox --volume /wd:/wd$"
 
-  echo "In sidecar mode (e.g. GitLab CI Docker-in-Docker service), volume args pass through unchanged"
-  sidecar_dind_id="$(docker run --detach --privileged --env DOCKER_TLS_CERTDIR="" docker:dind)"
+  echo "Passes through when the Docker is in a sidecar container"
+  sidecar_dind_id="$(docker run --detach --privileged --env DOCKER_TLS_CERTDIR="" "docker:${docker_version}-dind")"
   until docker exec "${sidecar_dind_id}" docker info >/dev/null 2>&1; do sleep 1; done
   "${docker_args[@]}" --env DOND_SHIM_PRINT_COMMAND=true \
     --link "${sidecar_dind_id}:dind" --env DOCKER_HOST="tcp://dind:2375" \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -36,7 +36,9 @@ unset script_path script_dir
 # this avoids messing with the test output during the tests itself
 echo "Pulling docker images used in tests"
 docker pull -q busybox
-docker pull -q "docker:${docker_version}-dind"
+for docker_version in "${docker_versions[@]}"; do
+  docker pull -q "docker:${docker_version}-dind"
+done
 
 for docker_version in "${docker_versions[@]}"; do
   echo "Testing with docker version: ${docker_version}"


### PR DESCRIPTION
Useful when dond is called inside a GitLab Pipeline, where the Docker Daemon usually runs as a sidecar container.

Also, this PR optimizes dond by avoiding a `docker info` call and `docker inspect`. Now it only calls a single `docker inspect` call.